### PR TITLE
Add initial Python 3 support

### DIFF
--- a/examples/broadcast.py
+++ b/examples/broadcast.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 
 sys.path.append('..')
@@ -13,7 +15,7 @@ class BroadcastApp(object):
         self.node = node
 
     def receive_packet(self, packet):
-        print Sim.scheduler.current_time(), self.node.hostname, packet.ident
+        print(Sim.scheduler.current_time(), self.node.hostname, packet.ident)
 
 
 def main():

--- a/examples/delay.py
+++ b/examples/delay.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 
 sys.path.append('..')
@@ -36,13 +38,13 @@ class Generator(object):
 class DelayHandler(object):
     @staticmethod
     def receive_packet(packet):
-        print (Sim.scheduler.current_time(),
+        print((Sim.scheduler.current_time(),
                packet.ident,
                packet.created,
                Sim.scheduler.current_time() - packet.created,
                packet.transmission_delay,
                packet.propagation_delay,
-               packet.queueing_delay)
+               packet.queueing_delay))
 
 
 def main():
@@ -64,7 +66,7 @@ def main():
 
     # setup packet generator
     destination = n2.get_address('n1')
-    max_rate = 1000000 / (1000 * 8)
+    max_rate = 1000000 // (1000 * 8)
     load = 0.8 * max_rate
     g = Generator(node=n1, destination=destination, load=load, duration=10)
     Sim.scheduler.add(delay=0, event='generate', handler=g.handle)

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 
 sys.path.append('..')
@@ -11,13 +13,13 @@ from networks.network import Network
 class DelayHandler(object):
     @staticmethod
     def receive_packet(packet):
-        print (Sim.scheduler.current_time(),
+        print((Sim.scheduler.current_time(),
                packet.ident,
                packet.created,
                Sim.scheduler.current_time() - packet.created,
                packet.transmission_delay,
                packet.propagation_delay,
-               packet.queueing_delay)
+               packet.queueing_delay))
 
 
 def main():

--- a/examples/transfer.py
+++ b/examples/transfer.py
@@ -1,3 +1,6 @@
+
+from __future__ import print_function
+
 import sys
 
 sys.path.append('..')
@@ -55,13 +58,13 @@ class Main(object):
     def diff(self):
         args = ['diff', '-u', self.filename, self.directory + '/' + self.filename]
         result = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()[0]
-        print
+        print()
         if not result:
-            print "File transfer correct!"
+            print("File transfer correct!")
         else:
-            print "File transfer failed. Here is the diff:"
-            print
-            print result
+            print("File transfer failed. Here is the diff:")
+            print()
+            print(result)
 
     def run(self):
         # parameters

--- a/src/link.py
+++ b/src/link.py
@@ -1,6 +1,6 @@
 import random
 
-from sim import Sim
+from .sim import Sim
 
 
 class Link(object):
@@ -46,7 +46,7 @@ class Link(object):
 
     def transmit(self, packet):
         packet.queueing_delay += Sim.scheduler.current_time() - packet.enter_queue
-        delay = (8.0 * packet.length) / self.bandwidth
+        delay = (8.0 * packet.length) // self.bandwidth
         packet.transmission_delay += delay
         packet.propagation_delay += self.propagation
         # schedule packet arrival at end of link

--- a/src/sim.py
+++ b/src/sim.py
@@ -1,4 +1,6 @@
-import scheduler
+from __future__ import print_function
+
+from . import scheduler
 
 
 class Sim(object):
@@ -12,4 +14,4 @@ class Sim(object):
     @staticmethod
     def trace(kind, message):
         if kind in Sim.debug:
-            print Sim.scheduler.current_time(), message
+            print(Sim.scheduler.current_time(), message)


### PR DESCRIPTION
Most automatic changes were made with `2to3`.
The majority of changes were for the `print` function and enforcing integer division where needed.

Bene doesn't really seem to depend on binary data much?
More revision may be needed.
Python 2 compatibility was actually very easy to keep (for now), so support's currently not dropped! I'm getting the same results with the example scripts in both Python 2.7 and 3.5.

Possible additions to Bene in the future:

 - Unit tests (maybe use the examples as tests?)
 - Find a way to avoid the `sys.path.append('..')` in the example files.
 - Type annotations. Makes life easier for both readability and maintainability, but may conflict with the current dynamic nature of Bene. Also precludes Python 2 compatibility (even if it's stated to not matter).