### PR TITLE
Convert Packet and Send/ReceiveBuffer to use bytes

### DIFF
--- a/examples/transfer.py
+++ b/examples/transfer.py
@@ -22,7 +22,7 @@ class AppHandler(object):
         self.directory = 'received'
         if not os.path.exists(self.directory):
             os.makedirs(self.directory)
-        self.f = open("%s/%s" % (self.directory, self.filename), 'w')
+        self.f = open("%s/%s" % (self.directory, self.filename), 'wb')
 
     def receive_data(self, data):
         Sim.trace('AppHandler', "application got %d bytes" % (len(data)))
@@ -94,7 +94,7 @@ class Main(object):
         c2 = TCP(t2, n2.get_address('n1'), 1, n1.get_address('n2'), 1, a, window=3000)
 
         # send a file
-        with open(self.filename, 'r') as f:
+        with open(self.filename, 'rb') as f:
             while True:
                 data = f.read(1000)
                 if not data:

--- a/examples/transfer.py
+++ b/examples/transfer.py
@@ -22,7 +22,7 @@ class AppHandler(object):
         self.directory = 'received'
         if not os.path.exists(self.directory):
             os.makedirs(self.directory)
-        self.f = open("%s/%s" % (self.directory, self.filename), 'wb')
+        self.f = open(os.path.join(self.directory, self.filename), 'wb')
 
     def receive_data(self, data):
         Sim.trace('AppHandler', "application got %d bytes" % (len(data)))
@@ -56,7 +56,7 @@ class Main(object):
         self.loss = options.loss
 
     def diff(self):
-        args = ['diff', '-u', self.filename, self.directory + '/' + self.filename]
+        args = ['diff', '-u', self.filename, os.path.join(self.directory, self.filename)]
         result = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()[0]
         print()
         if not result:

--- a/src/buffer.py
+++ b/src/buffer.py
@@ -7,7 +7,7 @@ class SendBuffer(object):
             value is the sequence number for the next data that has
             not yet been sent. The last value is the sequence number
             for the last data in the buffer."""
-        self.buffer = ''
+        self.buffer = b''
         self.base_seq = 0
         self.next_seq = 0
         self.last_seq = 0
@@ -128,7 +128,7 @@ class ReceiveBuffer(object):
     def get(self):
         """ Get and remove all data that is in order. Return the data
             and its starting sequence number. """
-        data = ''
+        data = b''
         start = self.base
         for sequence in sorted(self.buffer.keys()):
             chunk = self.buffer[sequence]

--- a/src/buffer.py
+++ b/src/buffer.py
@@ -98,13 +98,13 @@ class ReceiveBuffer(object):
             bytes."""
         self.buffer = {}
         # starting sequence number
-        self.base = 0
+        self.base_seq = 0
 
     def put(self, data, sequence):
         """ Add data to the receive buffer. Put it in order of
         sequence number and remove any duplicate data."""
         # ignore old chunk
-        if sequence < self.base:
+        if sequence < self.base_seq:
             return
         # ignore duplicate chunk
         if sequence in self.buffer:
@@ -129,12 +129,12 @@ class ReceiveBuffer(object):
         """ Get and remove all data that is in order. Return the data
             and its starting sequence number. """
         data = b''
-        start = self.base
+        start = self.base_seq
         for sequence in sorted(self.buffer.keys()):
             chunk = self.buffer[sequence]
-            if chunk.sequence == self.base:
+            if chunk.sequence == self.base_seq:
                 # append the data, adjust the base, delete the chunk
                 data += chunk.data
-                self.base += chunk.length
+                self.base_seq += chunk.length
                 del self.buffer[chunk.sequence]
         return data, start

--- a/src/packet.py
+++ b/src/packet.py
@@ -1,7 +1,7 @@
 class Packet(object):
     def __init__(self, source_address=1, source_port=0,
                  destination_address=1, destination_port=0,
-                 ident=0, ttl=100, protocol="None", body="", length=0):
+                 ident=0, ttl=100, protocol="None", body=b"", length=0):
         # standard packet fields
         self.source_address = source_address
         self.source_port = source_port


### PR DESCRIPTION
Python 3 should be using bytestrings for data that represents bytes. Otherwise it will default to Unicode.
The `b''` syntax also works in Python 2.7, so nothing appears to have broken.

Resolves #9.

Let me know what you think.